### PR TITLE
jira 3.10.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,13 @@
 {% set name = "jira" %}
-{% set version = "3.6.0" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_val = "4c67497fe8dc2f60f1c4f7b33479f059c928bec3db9dcb5cd7b6a09b6ecc0942" %}
+{% set version = "3.10.5" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash_val }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2d09ae3bf4741a2787dd889dfea5926a5d509aac3b28ab3b98c098709e6ee72d
 
 build:
   noarch: python
@@ -19,26 +15,29 @@ build:
     - jirashell = jira.jirashell:main
   number: 0
   script: python -m pip install --no-deps --no-build-isolation --ignore-installed . -v
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python
     - setuptools >=60.0.0
     - setuptools-scm >=7.0.0
-    - wheel
-
   run:
     - defusedxml
     - keyring
     - packaging
     - pillow >=2.1.0
-    - python >=3.8
+    - python
     - requests >=2.10.0
     - requests-oauthlib >=1.1.0
     - requests-toolbelt
     - typing_extensions >=3.7.4.2
     - ipython >=4.0.0
+  run_constrained:
+    - requests-futures >=0.9.7
+    - ipython >=4.0.0
+    - filemagic >=1.6
 
 test:
   imports:
@@ -48,18 +47,22 @@ test:
   commands:
     - pip check
     - jirashell --help
+    # check that pip gets the correct version
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/pycontribs/jira
   license: BSD-2-Clause
   license_file: LICENSE
   license_family: BSD
-  summary: 'The easiest way to automate JIRA'
+  summary: The easiest way to automate JIRA
   dev_url: https://github.com/pycontribs/jira
   doc_url: https://jira.readthedocs.io
   description: |-
     This library eases the use of the Jira REST API from Python and it has been
     used in production for years.
+
+
 
 extra:
   skip-lints:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - ipython >=4.0.0
   run_constrained:
     - requests-futures >=0.9.7
-    - ipython >=4.0.0
     - filemagic >=1.6
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - defusedxml
     - keyring
     - packaging
-    - pillow >=2.1.0
     - python
     - requests >=2.10.0
     - requests-oauthlib >=1.1.0


### PR DESCRIPTION
jira 3.10.5 

**Destination channel:** Defaults

### Links

- [PKG-9631]
- dev_url:        https://github.com/pycontribs/jira
- conda_forge:    https://github.com/conda-forge/jira-feedstock
- pypi:           https://pypi.org/project/jira/3.10.5
- pypi inspector: https://inspector.pypi.io/project/jira/3.10.5

### Explanation of changes:

- new version number
- some `run` dependencies are (certainly now) `run_constrained` but I've left them in -- remove at next major bump?

[latest build graph](https://package-build.anaconda.com/v1/graph/0cf61d95-95a9-46e6-9dbf-8c2c53fa0867)

[PKG-9631]: https://anaconda.atlassian.net/browse/PKG-9631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ